### PR TITLE
[FEAT]:Implement basic UI layout with Jetpack Compose

### DIFF
--- a/app/src/main/java/com/sesac/composenewsapp/MainActivity.kt
+++ b/app/src/main/java/com/sesac/composenewsapp/MainActivity.kt
@@ -1,0 +1,12 @@
+package com.sesac.composenewsapp
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { NewsScreen() } // 하나의 화면을 만들음.
+    }
+}

--- a/app/src/main/java/com/sesac/composenewsapp/NewsScreen.kt
+++ b/app/src/main/java/com/sesac/composenewsapp/NewsScreen.kt
@@ -1,0 +1,56 @@
+package com.sesac.composenewsapp
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.rememberAsyncImagePainter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewsScreen(viewModel: NewsViewModel = viewModel()) {
+    val newsList by viewModel.newsList.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchNews()
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("News App") }) }
+    ) { padding ->
+        LazyColumn(modifier = Modifier.padding(padding)) {
+            items(newsList) { article ->
+                NewsItem(article)
+            }
+        }
+    }
+}
+
+@Composable
+fun NewsItem(article: Article) {
+    Card(modifier = Modifier
+        .fillMaxWidth()
+        .padding(8.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            article.urlToImage?.let { imageUrl ->
+                Image(
+                    painter = rememberAsyncImagePainter(imageUrl),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .height(200.dp)
+                        .fillMaxWidth()
+                )
+            }
+            Text(text = article.title, style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = article.description ?: "No description",
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.sesac.composenewsapp.MainActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 📌 변경 사항
- `activity_main.xml` 레이아웃 추가
- `MainActivity.kt`에서 Jetpack Compose 적용
- `NewsScreen.kt`를 추가하여 뉴스 리스트 화면 구현

## ✅ 작업 내용
- Jetpack Compose 기반 UI 구조 설계
- Material3 컴포넌트 적용
- `LazyColumn`을 활용한 뉴스 리스트 UI 구현

## 📝 테스트 방법
1. `feature/ui-design` 브랜치를 `develop`에 병합
2. 앱을 실행하여 UI가 정상적으로 표시되는지 확인
3. 뉴스 리스트가 올바르게 렌더링되는지 테스트

## 🔥 기타
- 추후 API 연동 후 데이터 바인딩 필요
- 스타일 수정 및 추가 개선 가능
