### PR TITLE
[RELEASE]: Merge feature/ui-design and feature/news-api 병합

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# 📰 NewsApp - Kotlin & Jetpack Compose! 
+- Android 뉴스 앱 프로젝트  
+- Jetpack Compose와 Retrofit을 활용한 최신 뉴스 조회 앱입니다.  
+
+## 주요 기능
+✅ **최신 뉴스 조회** (NewsAPI 사용)  
+✅ **Jetpack Compose UI** 적용  
+✅ **ViewModel + StateFlow**를 활용한 상태 관리  
+✅ **Retrofit + Coroutine**으로 비동기 네트워크 요청  
+✅ **Coil을 활용한 뉴스 이미지 로딩**  
+
+---
+
+## 사용 기술
+- **언어:** Kotlin
+- **UI:** Jetpack Compose, Material 3
+- **비동기 처리:** Coroutine, Flow
+- **네트워크 통신:** Retrofit2, OkHttp
+- **상태 관리:** ViewModel, StateFlow
+- **이미지 로딩:** Coil
+
+---
+
+## 앱 화면  
+| 목록 화면  |
+|------------|
+| <img src="https://github.com/user-attachments/assets/2720d3f8-129c-40a5-890a-b0d16e8c8175" width="300"/> |
+
+---
+
+## 프로젝트 설정 방법
+
+### 1️⃣ **News API 키 추가**
+NewsAPI에서 API 키를 발급받고, `NewsApiService.kt` 파일에서 아래 부분을 수정하세요.  
+
+```kotlin
+@GET("v2/top-headlines")
+suspend fun getTopHeadlines(
+    @Query("country") country: String = "us",
+    @Query("apiKey") apiKey: String = "YOUR_API_KEY" // 👈 여기에 API 키 입력!
+): NewsResponse

--- a/app/src/main/java/com/sesac/composenewsapp/MainActivity.kt
+++ b/app/src/main/java/com/sesac/composenewsapp/MainActivity.kt
@@ -1,0 +1,12 @@
+package com.sesac.composenewsapp
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { NewsScreen() } // 하나의 화면을 만들음.
+    }
+}

--- a/app/src/main/java/com/sesac/composenewsapp/NewsScreen.kt
+++ b/app/src/main/java/com/sesac/composenewsapp/NewsScreen.kt
@@ -1,0 +1,56 @@
+package com.sesac.composenewsapp
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.rememberAsyncImagePainter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewsScreen(viewModel: NewsViewModel = viewModel()) {
+    val newsList by viewModel.newsList.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchNews()
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("News App") }) }
+    ) { padding ->
+        LazyColumn(modifier = Modifier.padding(padding)) {
+            items(newsList) { article ->
+                NewsItem(article)
+            }
+        }
+    }
+}
+
+@Composable
+fun NewsItem(article: Article) {
+    Card(modifier = Modifier
+        .fillMaxWidth()
+        .padding(8.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            article.urlToImage?.let { imageUrl ->
+                Image(
+                    painter = rememberAsyncImagePainter(imageUrl),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .height(200.dp)
+                        .fillMaxWidth()
+                )
+            }
+            Text(text = article.title, style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = article.description ?: "No description",
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.sesac.composenewsapp.MainActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 📌 변경 사항
- `feature/ui-design` 및 `feature/news-api` 브랜치를 `develop`에 병합 후 `main`으로 릴리즈 준비
- Jetpack Compose 기반 UI 추가
- Retrofit을 활용한 News API 연동 완료

## ✅ 작업 내용
- `activity_main.xml`, `MainActivity.kt`, `NewsScreen.kt`를 추가하여 기본 UI 구성
- `RetrofitInstance.kt`, `NewsApiService.kt`를 활용한 API 요청 구현
- `NewsViewModel.kt`에서 ViewModel과 StateFlow를 활용한 상태 관리 적용
- `Models.kt`에서 뉴스 데이터 모델 정의

## 📝 테스트 방법
1. `develop` 브랜치를 `main`에 병합
2. 앱을 실행하여 UI 및 API 데이터가 정상적으로 표시되는지 확인
3. 뉴스 리스트가 정상적으로 로드되고, UI가 깨지지 않는지 테스트
4. 네트워크 연결이 없을 때 예외 처리가 정상적으로 동작하는지 확인

## 🔥 기타
- 향후 API 응답 캐싱 및 로컬 데이터 저장 기능 추가 가능